### PR TITLE
kappa_d per UHECR

### DIFF
--- a/fancy/analysis/analysis.py
+++ b/fancy/analysis/analysis.py
@@ -409,7 +409,7 @@ class Analysis():
             'N': self.data.uhecr.N,
             'arrival_direction': self.data.uhecr.unit_vector,
             'A': self.data.uhecr.A,
-            'kappa_d': self.data.detector.kappa_d,
+            'kappa_d': self.data.uhecr.kappa_d,
             'alpha_T': alpha_T,
             'Ngrid': len(kappa_grid),
             'eps': eps_fit,

--- a/fancy/interfaces/__init__.py
+++ b/fancy/interfaces/__init__.py
@@ -1,2 +1,3 @@
 from .data import *
+from .uhecr import *
 from .integration import *

--- a/fancy/interfaces/data.py
+++ b/fancy/interfaces/data.py
@@ -49,16 +49,17 @@ class Data():
         # define source object
         self.source = new_source
 
-    def add_uhecr(self, filename, label=None):
+    def add_uhecr(self, filename, label=None, ptype="p"):
         """
         Add a uhecr object to the data container from file.
 
         :param filename: name of the file containing the object's data
         :param label: reference label for the uhecr dataset
+        :param ptype: composition type, this should be contained in the dataset itself
         """
 
         new_uhecr = Uhecr()
-        new_uhecr.from_data_file(filename, label)
+        new_uhecr.from_data_file(filename, label, ptype)
 
         # define uhecr object
         self.uhecr = new_uhecr

--- a/fancy/interfaces/data.py
+++ b/fancy/interfaces/data.py
@@ -7,6 +7,7 @@ from astropy.coordinates import SkyCoord, EarthLocation
 from datetime import date, timedelta
 import h5py
 
+from .uhecr import Uhecr
 from .stan import coord_to_uv, uv_to_coord
 from ..detector.detector import Detector
 from ..plotting import AllSkyMap
@@ -271,7 +272,7 @@ class Source():
             self.N = len(self.distance)
             glon = data['glon'][()]
             glat = data['glat'][()]
-            self.coord = get_coordinates(glon, glat)
+            self.coord = self.get_coordinates(glon, glat)
 
             if self.label != 'cosmo_150' and self.label != 'VCV_AGN':
                 # Get names
@@ -399,338 +400,21 @@ class Source():
             print('No fluxes to select on.')
 
 
-class Uhecr():
-    """
-    Stores the data and parameters for UHECRs
-    """
-    def __init__(self):
-        """
-        Initialise empty container.
-        """
-
-        self.properties = None
-        self.source_labels = None
-
-    def from_data_file(self, filename, label, exp_factor = 1.):
-        """
-        Define UHECR from data file of original information.
-        
-        Handles calculation of observation periods and 
-        effective areas assuming the UHECR are detected 
-        by the Pierre Auger Observatory or TA.
-        
-        :param filename: name of the data file
-        :param label: reference label for the UHECR data set 
-        """
-
-        self.label = label
-
-        with h5py.File(filename, 'r') as f:
-
-            data = f[self.label]
-
-            self.year = data['year'][()]
-            self.day = data['day'][()]
-            self.zenith_angle = np.deg2rad(data['theta'][()])
-            self.energy = data['energy'][()]
-            self.N = len(self.energy)
-            glon = data['glon'][()]
-            glat = data['glat'][()]
-            self.coord = get_coordinates(glon, glat)
-
-            self.unit_vector = coord_to_uv(self.coord)
-            self.period = self._find_period()
-            self.A = self._find_area(exp_factor)
-
-    def _get_properties(self):
-        """
-        Convenience function to pack object into dict.
-        """
-
-        self.properties = {}
-        self.properties['label'] = self.label
-        self.properties['N'] = self.N
-        self.properties['unit_vector'] = self.unit_vector
-        self.properties['energy'] = self.energy
-        self.properties['A'] = self.A
-        self.properties['zenith_angle'] = self.zenith_angle
-
-        # Only if simulated UHECRs
-        if isinstance(self.source_labels, (list, np.ndarray)):
-            self.properties['source_labels'] = self.source_labels
-
-    def from_properties(self, uhecr_properties):
-        """
-        Define UHECR from properties dict.
-            
-        :param uhecr_properties: dict containing UHECR properties.
-        :param label: identifier
-        """
-
-        self.label = uhecr_properties['label']
-
-        # Read from input dict
-        self.N = uhecr_properties['N']
-        self.unit_vector = uhecr_properties['unit_vector']
-        self.energy = uhecr_properties['energy']
-        self.zenith_angle = uhecr_properties['zenith_angle']
-        self.A = uhecr_properties['A']
-
-        # Only if simulated UHECRs
-        try:
-            self.source_labels = uhecr_properties['source_labels']
-        except:
-            pass
-
-        # Get SkyCoord from unit_vector
-        self.coord = uv_to_coord(self.unit_vector)
-
-    def plot(self, skymap, size=2):
-        """
-        Plot the Uhecr instance on a skymap.
-
-        Called by Data.show()
-      
-        :param skymap: the AllSkyMap
-        :param size: tissot radius
-        :param source_labels: source labels (int)
-        """
-
-        lons = self.coord.galactic.l.deg
-        lats = self.coord.galactic.b.deg
-
-        alpha_level = 0.7
-
-        # If source labels are provided, plot with colour
-        # indicating the source label.
-        if isinstance(self.source_labels, (list, np.ndarray)):
-
-            Nc = max(self.source_labels)
-
-            # Use a continuous cmap
-            cmap = plt.cm.get_cmap('plasma', Nc)
-
-            write_label = True
-
-            for lon, lat, lab in np.nditer([lons, lats, self.source_labels]):
-                color = cmap(lab)
-                if write_label:
-                    skymap.tissot(lon,
-                                  lat,
-                                  size,
-                                  npts=30,
-                                  facecolor=color,
-                                  alpha=0.5,
-                                  label=self.label)
-                    write_label = False
-                else:
-                    skymap.tissot(lon,
-                                  lat,
-                                  size,
-                                  npts=30,
-                                  facecolor=color,
-                                  alpha=0.5)
-
-        # Otherwise, use the cmap to show the UHECR energy.
-        else:
-
-            # use colormap for energy
-            norm_E = matplotlib.colors.Normalize(min(self.energy),
-                                                 max(self.energy))
-            cmap = plt.cm.get_cmap('viridis', len(self.energy))
-
-            write_label = True
-            for E, lon, lat in np.nditer([self.energy, lons, lats]):
-
-                color = cmap(norm_E(E))
-
-                if write_label:
-                    skymap.tissot(lon,
-                                  lat,
-                                  size,
-                                  30,
-                                  facecolor=color,
-                                  alpha=alpha_level,
-                                  label=self.label)
-                    write_label = False
-                else:
-                    skymap.tissot(lon,
-                                  lat,
-                                  size,
-                                  30,
-                                  facecolor=color,
-                                  alpha=alpha_level)
-
-    def save(self, file_handle):
-        """
-        Save to the passed H5py file handle,
-        i.e. something that cna be used with 
-        file_handle.create_dataset()
-        
-        :param file_handle: file handle
-        """
-
-        self._get_properties()
-
-        for key, value in self.properties.items():
-            file_handle.create_dataset(key, data=value)
-
-    def _find_area(self, exp_factor):
-        """
-        Find the effective area of the observatory at 
-        the time of detection.
-
-        Possible areas are calculated from the exposure reported
-        in Abreu et al. (2010) or Collaboration et al. 2014.
-        """
-
-        if self.label == 'auger2010':
-            from ..detector.auger2010 import A1, A2, A3
-            possible_areas = [A1, A2, A3]
-            area = [possible_areas[i - 1]* exp_factor  for i in self.period]
-
-        elif self.label == 'auger2014':
-            from ..detector.auger2014 import A1, A2, A3, A4, A1_incl, A2_incl, A3_incl, A4_incl
-            possible_areas_vert = [A1, A2, A3, A4]
-            possible_areas_incl = [A1_incl, A2_incl, A3_incl, A4_incl]
-
-            # find area depending on period and incl
-            area = []
-            for i, p in enumerate(self.period):
-                if self.zenith_angle[i] <= 60:
-                    area.append(possible_areas_vert[p - 1]* exp_factor )
-                if self.zenith_angle[i] > 60:
-                    area.append(possible_areas_incl[p - 1]* exp_factor )
-
-        elif self.label == 'TA2015':
-            from ..detector.TA2015 import A1, A2
-            possible_areas = [A1, A2]
-            area = [possible_areas[i - 1] * exp_factor for i in self.period]
-
-        else:
-            print('Error: effective areas and periods not defined')
-
-        return area
-
-    def _find_period(self):
-        """
-        For a given year or day, find UHECR period based on dates
-        in table 1 in Abreu et al. (2010) or in Collaboration et al. 2014.
-        """
-
-        period = []
-        if self.label == "auger2014":
-            from ..detector.auger2014 import (period_1_start, period_1_end,
-                                            period_2_start, period_2_end,
-                                            period_3_start, period_3_end,
-                                            period_4_start, period_4_end)
-
-            # check dates
-            for y, d in np.nditer([self.year, self.day]):
-                d = int(d)
-                test_date = date(y, 1, 1) + timedelta(d)
-
-                if period_1_start <= test_date <= period_1_end:
-                    period.append(1)
-                elif period_2_start <= test_date <= period_2_end:
-                    period.append(2)
-                elif period_3_start <= test_date <= period_3_end:
-                    period.append(3)
-                elif test_date >= period_3_end:
-                    period.append(4)
-                else:
-                    print('Error: cannot determine period for year', y, 'and day',
-                        d)
-
-        elif self.label == "TA2015":
-            from ..detector.TA2015 import (period_1_start, period_1_end,
-                                            period_2_start, period_2_end)
-            for y, d in np.nditer([self.year, self.day]):
-                d = int(d)
-                test_date = date(y, 1, 1) + timedelta(d)
-
-                if period_1_start <= test_date <= period_1_end:
-                    period.append(1)
-                elif period_2_start <= test_date <= period_2_end:
-                    period.append(2)
-                elif test_date >= period_2_end:
-                    period.append(2)
-                else:
-                    print('Error: cannot determine period for year', y, 'and day',
-                        d)    
-
-        return period
-
-    def select_period(self, period):
-        """
-        Select certain periods for analysis, other periods will be discarded. 
-        """
-
-        # find selected periods
-        if len(period) == 1:
-            selection = np.where(np.asarray(self.period) == period[0])
-        if len(period) == 2:
-            selection = np.concatenate([
-                np.where(np.asarray(self.period) == period[0]),
-                np.where(np.asarray(self.period) == period[1])
-            ],
-                                       axis=1)
-
-        # keep things as lists
-        selection = selection[0].tolist()
-
-        # make selection
-        self.A = [self.A[i] for i in selection]
-        self.period = [self.period[i] for i in selection]
-        self.energy = [self.energy[i] for i in selection]
-        self.incidence_angle = [self.incidence_angle[i] for i in selection]
-        self.unit_vector = [self.unit_vector[i] for i in selection]
-
-        self.N = len(self.period)
-
-        self.day = [self.day[i] for i in selection]
-        self.year = [self.year[i] for i in selection]
-
-        self.coord = self.coord[selection]
-
-    def select_energy(self, Eth):
-        """
-        Select out only UHECRs above a certain energy.
-        """
-
-        selection = np.where(np.asarray(self.energy) >= Eth)
-        selection = selection[0].tolist()
-
-        # make selection
-        self.A = [self.A[i] for i in selection]
-        self.period = [self.period[i] for i in selection]
-        self.energy = [self.energy[i] for i in selection]
-        self.incidence_angle = [self.incidence_angle[i] for i in selection]
-        self.unit_vector = [self.unit_vector[i] for i in selection]
-
-        self.N = len(self.period)
-
-        self.day = [self.day[i] for i in selection]
-        self.year = [self.year[i] for i in selection]
-
-        self.coord = self.coord[selection]
-
-
 # convenience functions
 
 
-def get_coordinates(glon, glat, D=None):
-    """
-    Convert glon and glat to astropy SkyCoord
-    Add distance if possible (allows conversion to cartesian coords)
-        
-    :return: astropy.coordinates.SkyCoord
-    """
+    def get_coordinates(self, glon, glat, D=None):
+        """
+        Convert glon and glat to astropy SkyCoord
+        Add distance if possible (allows conversion to cartesian coords)
+            
+        :return: astropy.coordinates.SkyCoord
+        """
 
-    if D:
-        return SkyCoord(l=glon * u.degree,
-                        b=glat * u.degree,
-                        frame='galactic',
-                        distance=D * u.mpc)
-    else:
-        return SkyCoord(l=glon * u.degree, b=glat * u.degree, frame='galactic')
+        if D:
+            return SkyCoord(l=glon * u.degree,
+                            b=glat * u.degree,
+                            frame='galactic',
+                            distance=D * u.mpc)
+        else:
+            return SkyCoord(l=glon * u.degree, b=glat * u.degree, frame='galactic')

--- a/fancy/interfaces/make_nuclear_table.py
+++ b/fancy/interfaces/make_nuclear_table.py
@@ -1,0 +1,25 @@
+import pickle
+import os
+
+'''Make nuclear table in which composition type is read from user input.
+Table reads in periodic element and returns (A, Z) of that element.
+Add more elements as needed here.'''
+
+
+if __name__ == "__main__":
+    this_fpath = os.path.abspath(os.path.dirname(__file__))
+
+    table = {
+        "p" : (1, 1),
+        "H" : (1, 1),
+        "He" : (4, 2),
+        "Li" : (7, 3),
+        "C" : (12,6),
+        "N" : (14, 7),
+        "O" : (16, 8),
+        "Si" : (28, 14),
+        "Fe" : (56, 26)
+    }
+
+    with open(os.path.join(this_fpath, "nuclear_table.pkl"), "wb") as f:
+        pickle.dump(table, f)

--- a/fancy/interfaces/stan.py
+++ b/fancy/interfaces/stan.py
@@ -61,7 +61,8 @@ class Model():
               L=None,
               F0=None,
               alpha=None,
-              Eth=None):
+              Eth=None,
+              ptype=None):
         """
         Get simulation inputs.
 
@@ -71,6 +72,7 @@ class Model():
         :param B: rms B field strength [nG]
         :param alpha: source spectral index
         :param Eth: threshold energy of study [EeV]
+        :param ptype: element of composition
         """
         self.F_T = F_T
         self.f = f
@@ -81,6 +83,7 @@ class Model():
         self.alpha = alpha
         self.Eth = Eth
         self.Eth_sim = None  # To be set by Analysis
+        self.ptype = ptype
 
     def _get_properties(self):
         """

--- a/fancy/interfaces/uhecr.py
+++ b/fancy/interfaces/uhecr.py
@@ -1,0 +1,511 @@
+import pandas as pd
+import numpy as np
+import matplotlib
+from matplotlib import pyplot as plt
+from astropy import units as u
+from astropy.coordinates import SkyCoord, EarthLocation
+from datetime import date, timedelta
+import h5py
+from scipy.optimize import root
+
+from .stan import coord_to_uv, uv_to_coord
+from ..detector.detector import Detector
+from ..plotting import AllSkyMap
+
+# importing crpropa, need to append system path
+import sys
+sys.path.append("/opt/CRPropa3/lib/python3.8/site-packages")
+import crpropa
+
+__all__ = ['Uhecr']
+
+
+class Uhecr():
+    """
+    Stores the data and parameters for UHECRs
+    """
+    def __init__(self):
+        """
+        Initialise empty container.
+        """
+
+        self.properties = None
+        self.source_labels = None
+
+    def get_angerr(self):
+        '''Get angular reconstruction uncertainty from label'''
+
+        if self.label == "TA2015":
+            from fancy.detector.TA2015 import sig_omega
+        elif self.label == "auger2014":
+            from fancy.detector.auger2014 import sig_omega
+        elif self.label == "auger2010":
+            from fancy.detector.auger2010 import sig_omega
+        else:
+            raise Exception("Undefined detector type!")
+
+        return np.deg2rad(sig_omega)
+        
+
+    def from_data_file(self, filename, label, exp_factor = 1.):
+        """
+        Define UHECR from data file of original information.
+        
+        Handles calculation of observation periods and 
+        effective areas assuming the UHECR are detected 
+        by the Pierre Auger Observatory or TA.
+        
+        :param filename: name of the data file
+        :param label: reference label for the UHECR data set 
+        """
+
+        self.label = label
+
+        with h5py.File(filename, 'r+') as f:
+
+            data = f[self.label]
+
+            self.year = data['year'][()]
+            self.day = data['day'][()]
+            self.zenith_angle = np.deg2rad(data['theta'][()])
+            self.energy = data['energy'][()]
+            self.N = len(self.energy)
+            glon = data['glon'][()]
+            glat = data['glat'][()]
+            self.coord = self.get_coordinates(glon, glat)
+
+            self.unit_vector = coord_to_uv(self.coord)
+            self.period = self._find_period()
+            self.A = self._find_area(exp_factor)
+
+            if "kappa_d" in list(data.keys()):
+                self.kappa_d = data["kappa_d"][()]
+            else:
+                self.kappa_d = self.eval_kappad(plot=False)
+                data.create_dataset("kappa_d", data=self.kappa_d)
+
+    def _get_properties(self):
+        """
+        Convenience function to pack object into dict.
+        """
+
+        self.properties = {}
+        self.properties['label'] = self.label
+        self.properties['N'] = self.N
+        self.properties['unit_vector'] = self.unit_vector
+        self.properties['energy'] = self.energy
+        self.properties['A'] = self.A
+        self.properties['zenith_angle'] = self.zenith_angle
+
+        # Only if simulated UHECRs
+        if isinstance(self.source_labels, (list, np.ndarray)):
+            self.properties['source_labels'] = self.source_labels
+
+    def from_properties(self, uhecr_properties):
+        """
+        Define UHECR from properties dict.
+            
+        :param uhecr_properties: dict containing UHECR properties.
+        :param label: identifier
+        """
+
+        self.label = uhecr_properties['label']
+
+        # Read from input dict
+        self.N = uhecr_properties['N']
+        self.unit_vector = uhecr_properties['unit_vector']
+        self.energy = uhecr_properties['energy']
+        self.zenith_angle = uhecr_properties['zenith_angle']
+        self.A = uhecr_properties['A']
+
+        # Only if simulated UHECRs
+        try:
+            self.source_labels = uhecr_properties['source_labels']
+        except:
+            pass
+
+        # Get SkyCoord from unit_vector
+        self.coord = uv_to_coord(self.unit_vector)
+        self.kappa_d = self.eval_kappad()
+
+    def plot(self, skymap, size=2):
+        """
+        Plot the Uhecr instance on a skymap.
+
+        Called by Data.show()
+      
+        :param skymap: the AllSkyMap
+        :param size: tissot radius
+        :param source_labels: source labels (int)
+        """
+
+        lons = self.coord.galactic.l.deg
+        lats = self.coord.galactic.b.deg
+
+        alpha_level = 0.7
+
+        # If source labels are provided, plot with colour
+        # indicating the source label.
+        if isinstance(self.source_labels, (list, np.ndarray)):
+
+            Nc = max(self.source_labels)
+
+            # Use a continuous cmap
+            cmap = plt.cm.get_cmap('plasma', Nc)
+
+            write_label = True
+
+            for lon, lat, lab in np.nditer([lons, lats, self.source_labels]):
+                color = cmap(lab)
+                if write_label:
+                    skymap.tissot(lon,
+                                  lat,
+                                  size,
+                                  npts=30,
+                                  facecolor=color,
+                                  alpha=0.5,
+                                  label=self.label)
+                    write_label = False
+                else:
+                    skymap.tissot(lon,
+                                  lat,
+                                  size,
+                                  npts=30,
+                                  facecolor=color,
+                                  alpha=0.5)
+
+        # Otherwise, use the cmap to show the UHECR energy.
+        else:
+
+            # use colormap for energy
+            norm_E = matplotlib.colors.Normalize(min(self.energy),
+                                                 max(self.energy))
+            cmap = plt.cm.get_cmap('viridis', len(self.energy))
+
+            write_label = True
+            for E, lon, lat in np.nditer([self.energy, lons, lats]):
+
+                color = cmap(norm_E(E))
+
+                if write_label:
+                    skymap.tissot(lon,
+                                  lat,
+                                  size,
+                                  30,
+                                  facecolor=color,
+                                  alpha=alpha_level,
+                                  label=self.label)
+                    write_label = False
+                else:
+                    skymap.tissot(lon,
+                                  lat,
+                                  size,
+                                  30,
+                                  facecolor=color,
+                                  alpha=alpha_level)
+
+    def save(self, file_handle):
+        """
+        Save to the passed H5py file handle,
+        i.e. something that cna be used with 
+        file_handle.create_dataset()
+        
+        :param file_handle: file handle
+        """
+
+        self._get_properties()
+
+        for key, value in self.properties.items():
+            file_handle.create_dataset(key, data=value)
+
+    def _find_area(self, exp_factor):
+        """
+        Find the effective area of the observatory at 
+        the time of detection.
+
+        Possible areas are calculated from the exposure reported
+        in Abreu et al. (2010) or Collaboration et al. 2014.
+        """
+
+        if self.label == 'auger2010':
+            from ..detector.auger2010 import A1, A2, A3
+            possible_areas = [A1, A2, A3]
+            area = [possible_areas[i - 1]* exp_factor  for i in self.period]
+
+        elif self.label == 'auger2014':
+            from ..detector.auger2014 import A1, A2, A3, A4, A1_incl, A2_incl, A3_incl, A4_incl
+            possible_areas_vert = [A1, A2, A3, A4]
+            possible_areas_incl = [A1_incl, A2_incl, A3_incl, A4_incl]
+
+            # find area depending on period and incl
+            area = []
+            for i, p in enumerate(self.period):
+                if self.zenith_angle[i] <= 60:
+                    area.append(possible_areas_vert[p - 1]* exp_factor )
+                if self.zenith_angle[i] > 60:
+                    area.append(possible_areas_incl[p - 1]* exp_factor )
+
+        elif self.label == 'TA2015':
+            from ..detector.TA2015 import A1, A2
+            possible_areas = [A1, A2]
+            area = [possible_areas[i - 1] * exp_factor for i in self.period]
+
+        else:
+            print('Error: effective areas and periods not defined')
+
+        return area
+
+    def _find_period(self):
+        """
+        For a given year or day, find UHECR period based on dates
+        in table 1 in Abreu et al. (2010) or in Collaboration et al. 2014.
+        """
+
+        period = []
+        if self.label == "auger2014":
+            from ..detector.auger2014 import (period_1_start, period_1_end,
+                                            period_2_start, period_2_end,
+                                            period_3_start, period_3_end,
+                                            period_4_start, period_4_end)
+
+            # check dates
+            for y, d in np.nditer([self.year, self.day]):
+                d = int(d)
+                test_date = date(y, 1, 1) + timedelta(d)
+
+                if period_1_start <= test_date <= period_1_end:
+                    period.append(1)
+                elif period_2_start <= test_date <= period_2_end:
+                    period.append(2)
+                elif period_3_start <= test_date <= period_3_end:
+                    period.append(3)
+                elif test_date >= period_3_end:
+                    period.append(4)
+                else:
+                    print('Error: cannot determine period for year', y, 'and day',
+                        d)
+
+        elif self.label == "TA2015":
+            from ..detector.TA2015 import (period_1_start, period_1_end,
+                                            period_2_start, period_2_end)
+            for y, d in np.nditer([self.year, self.day]):
+                d = int(d)
+                test_date = date(y, 1, 1) + timedelta(d)
+
+                if period_1_start <= test_date <= period_1_end:
+                    period.append(1)
+                elif period_2_start <= test_date <= period_2_end:
+                    period.append(2)
+                elif test_date >= period_2_end:
+                    period.append(2)
+                else:
+                    print('Error: cannot determine period for year', y, 'and day',
+                        d)    
+
+        return period
+
+    def select_period(self, period):
+        """
+        Select certain periods for analysis, other periods will be discarded. 
+        """
+
+        # find selected periods
+        if len(period) == 1:
+            selection = np.where(np.asarray(self.period) == period[0])
+        if len(period) == 2:
+            selection = np.concatenate([
+                np.where(np.asarray(self.period) == period[0]),
+                np.where(np.asarray(self.period) == period[1])
+            ],
+                                       axis=1)
+
+        # keep things as lists
+        selection = selection[0].tolist()
+
+        # make selection
+        self.A = [self.A[i] for i in selection]
+        self.period = [self.period[i] for i in selection]
+        self.energy = [self.energy[i] for i in selection]
+        self.incidence_angle = [self.incidence_angle[i] for i in selection]
+        self.unit_vector = [self.unit_vector[i] for i in selection]
+
+        self.N = len(self.period)
+
+        self.day = [self.day[i] for i in selection]
+        self.year = [self.year[i] for i in selection]
+
+        self.coord = self.coord[selection]
+
+    def select_energy(self, Eth):
+        """
+        Select out only UHECRs above a certain energy.
+        """
+
+        selection = np.where(np.asarray(self.energy) >= Eth)
+        selection = selection[0].tolist()
+
+        # make selection
+        self.A = [self.A[i] for i in selection]
+        self.period = [self.period[i] for i in selection]
+        self.energy = [self.energy[i] for i in selection]
+        self.incidence_angle = [self.incidence_angle[i] for i in selection]
+        self.unit_vector = [self.unit_vector[i] for i in selection]
+
+        self.N = len(self.period)
+
+        self.day = [self.day[i] for i in selection]
+        self.year = [self.year[i] for i in selection]
+
+        self.coord = self.coord[selection]
+
+
+    def get_coordinates(self, glon, glat, D=None):
+        """
+        Convert glon and glat to astropy SkyCoord
+        Add distance if possible (allows conversion to cartesian coords)
+            
+        :return: astropy.coordinates.SkyCoord
+        """
+
+        if D:
+            return SkyCoord(l=glon * u.degree,
+                            b=glat * u.degree,
+                            frame='galactic',
+                            distance=D * u.mpc)
+        else:
+            return SkyCoord(l=glon * u.degree, b=glat * u.degree, frame='galactic')
+
+    def coord_to_vector3d(self):
+        '''Convert from SkyCoord array to Vector3d list'''
+        uhecr_vector3d = []
+
+        # due to how SkyCoord defines coordinates,
+        # lon_vector3d = pi - lon_skycoord
+        # lat_vector3d = pi/2 - lat_skycoord
+        for coord in self.coord:
+            v = crpropa.Vector3d()
+            v.setRThetaPhi(1, np.pi / 2. - coord.galactic.b.rad, np.pi - coord.galactic.l.rad)
+            uhecr_vector3d.append(v)
+        return uhecr_vector3d
+
+    def _prepare_crpropasim(self, particle_type="p", model_name="JF12", seed=691342):
+        '''Set up CRPropa simulation with some magnetic field model'''
+        sim = crpropa.ModuleList()
+
+        # setup magnetic field
+        if model_name == "JF12":
+            gmf = crpropa.JF12Field()
+            gmf.randomStriated(seed)
+            gmf.randomTurbulent(seed)
+        else:
+            gmf = crpropa.JF12Field()
+            gmf.randomStriated(seed)
+            gmf.randomTurbulent(seed)
+
+        # Propagation model, parameters: (B-field model, target error, min step, max step)
+        sim.add(crpropa.PropagationCK(gmf, 1e-4, 0.1 * crpropa.parsec, 100 * crpropa.parsec))
+        obs = crpropa.Observer()
+
+        # observer at galactic boundary (20 kpc)
+        obs.add(crpropa.ObserverSurface( crpropa.Sphere(crpropa.Vector3d(0), 20 * crpropa.kpc) ))
+        # obs.onDetection(TextOutput('galactic_backtracking.txt', Output.Event3D))
+        sim.add(obs)
+        # print(sim)
+
+        # composition, assume proton for now
+        # - nucleusId(A, Z)
+        pid = - crpropa.nucleusId(1, 1)
+        # pid = - crpropa.nucleusId(28, 14)
+
+        # CRPropa random number generator
+        crpropa_randgen = crpropa.Random() 
+
+        # position of earth in galactic coordinates
+        pos_earth = crpropa.Vector3d(-8.5, 0, 0) * crpropa.kpc
+
+        return sim, pid, crpropa_randgen, pos_earth
+
+    def _plot_deflections(self, defl_arrdirs, rand_arrdirs):
+        '''Plot deflections for particulat UHECR dataset'''
+        # check with basic mpl mollweide projection
+        plt.figure(figsize=(12,7))
+        ax = plt.subplot(111, projection = 'mollweide')
+
+        # get lon and lat arrays for future reference
+        # shift lons by 180. due to how its defined in mpl
+        uhecr_lons = np.pi - self.coord.galactic.l.rad
+        uhecr_lats = self.coord.galactic.b.rad
+
+        ax.scatter(uhecr_lons, uhecr_lats, color="k", marker="+", s=10.0, alpha=1., label="True")
+        for i in range(self.N):
+            ax.scatter(defl_arrdirs[i, :, 0], defl_arrdirs[i, :, 1], color="b", alpha=0.05, s=4.0)
+            ax.scatter(rand_arrdirs[i, :, 0], rand_arrdirs[i, :, 1], color="r", alpha=0.05, s=4.0)
+
+        # TODO: add labels based on color 
+        ax.grid()
+
+
+    def eval_kappad(self, Nrand = 100, particle_type="p", plot=False):
+        '''
+        Evaluate spread parameter between arrival direction
+        and deflected direction at galactic magnetic field
+        '''
+
+        # get angular reconstruction uncertainty
+        ang_err = self.get_angerr()
+        # evaluate vector3d object of arrival direction
+        uhecr_vector3d = self.coord_to_vector3d()
+        # prepare inputs / initializations for CRPropa simulation
+        sim, pid, R, pos = self._prepare_crpropasim(particle_type)
+
+        rand_arrdirs = np.zeros((self.N, Nrand, 2))
+        defl_arrdirs = np.zeros((self.N, Nrand, 2))
+
+        # evaluated kappa_d
+        kappa_ds = np.zeros((self.N, Nrand))
+
+        for i, arr_dir in enumerate(uhecr_vector3d):
+            energy = self.energy[i] * crpropa.EeV
+            for j in range(Nrand):
+                rand_arrdir = R.randVectorAroundMean(arr_dir, ang_err)
+
+                c = crpropa.Candidate(crpropa.ParticleState(pid, energy, pos, rand_arrdir))
+                sim.run(c)
+
+                defl_dir = c.current.getDirection()
+
+                # append longitudes and latitudes
+                # need to append np.pi / 2 - theta for latitude
+                # also append the randomized arrival direction in lons and lats
+                rand_arrdirs[i, j, :] = rand_arrdir.getPhi(), np.pi / 2. - rand_arrdir.getTheta()
+                defl_arrdirs[i, j, :] = defl_dir.getPhi(), np.pi / 2. - defl_dir.getTheta()
+
+                # evaluate dot product between arrival direction (randomized) and deflected vector
+                # dot exists with Vector3d() objects
+                cos_theta = rand_arrdir.dot(defl_dir)
+
+                # use scipy.optimize.root to get kappa_d using
+                # dot product
+                # P = 0.683 as per Soiaporn paper
+                sol = root(fischer_int_eq_P, x0=100, args=(cos_theta, 0.683))
+                # print(sol)   # check solution
+
+                kappa_ds[i, j] = sol.x[0]
+
+        if plot:
+            self._plot_deflections(defl_arrdirs, rand_arrdirs)
+
+        # evaluate mean kappa_d for each uhecr
+        kappa_d_mean = np.mean(kappa_ds, axis=1)
+
+        return kappa_d_mean
+
+
+'''Integral of Fischer distribution used to evaluate kappa_d'''
+def fischer_int(kappa, cos_thetaP):
+    '''Integral of vMF function over all angles'''
+    return (1. - np.exp(-kappa * (1 - cos_thetaP))) / (1. - np.exp(-2.*kappa))
+
+def fischer_int_eq_P(kappa, cos_thetaP, P):
+    '''Equation to find roots for'''
+    return fischer_int(kappa, cos_thetaP) - P

--- a/fancy/interfaces/utils.py
+++ b/fancy/interfaces/utils.py
@@ -1,0 +1,12 @@
+import pickle
+import os
+
+
+def get_nucleartable():
+    '''Read dictionary from nuclear_table.pkl'''
+    this_fpath = os.path.abspath(os.path.dirname(__file__))
+
+    with open(os.path.join(this_fpath, "nuclear_table.pkl"), "rb") as f:
+        nuc_table = pickle.load(f)
+
+    return nuc_table


### PR DESCRIPTION
kappa_d, which is the spread parameter in the vMF distribution for the angular reconstruction uncertainty, is now evaluated between:
- randomized arrival direction at earth with uncertainty as angular reconstruction
- resulting deflected direction at gal. boundary

to account for the galactic magnetic field and its more complex behaviour (rather than a simple averaged B-field).

This feature is now implemented for different elements, given in `fancy/interfaces/nuclear_tables.pkl`, and the kappa_d values can be constructed for each UHECR dataset in `precompute_tables.ipynb`.

To implement this, one needs to enable "joint_gmf" as the analysis_type, and use the "joint_gmf_model.stan" as the Model instead. The particle type can be set by specifing ptype in `Data.add_uhecr()`. The rest of the simulation works as usual. Check `gmf/fits_to_data/run_simulation.ipynb` for details.