### PR TITLE
removed ligo.skymap dependency, fixed pytests

### DIFF
--- a/fancy/plotting/allskymap.py
+++ b/fancy/plotting/allskymap.py
@@ -1,6 +1,12 @@
 import numpy as np
 from matplotlib import pyplot as plt
-import ligo.skymap.plot
+import sys
+
+try:
+    import ligo.skymap.plot
+except ImportError:
+    pass
+
 from matplotlib.patches import PathPatch, Polygon
 from matplotlib.path import Path
 
@@ -53,6 +59,9 @@ class SphericalCircle(PathPatch):
     def __init__(
         self, center, radius, resolution=100, lon_0=0.0, vertex_unit=u.degree, **kwargs
     ):
+        # raise issue if ligo.skymap is not installed
+        if "ligo.skymap" not in sys.modules:
+            raise ImportError("ligo.skymap (>=py39) needs to be installed to use this functionality.")
 
         boundary = (lon_0 + 180) % 360
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ install_requires =
     tqdm
     h5py
     pyproj
-    ligo.skymap
     pandas
     cmdstanpy
     seaborn

--- a/tests/test_allskymap.py
+++ b/tests/test_allskymap.py
@@ -1,12 +1,21 @@
+import sys
 import numpy as np
 from pathlib import Path
+
+try:
+    import ligo.skymap.plot
+except ImportError:
+    pass
+
+import pytest
 
 from fancy.plotting import AllSkyMap
 
 from fancy.detector.auger2014 import detector_properties
 from fancy.detector.detector import Detector
 
-
+@pytest.mark.skipif('ligo.skymap' not in sys.modules,
+                    reason="requires ligo.skymap")
 def test_basic_plotting(random_seed):
 
     np.random.seed(random_seed)
@@ -27,6 +36,8 @@ def test_basic_plotting(random_seed):
         skymap.scatter(lon, lat, color="k", linewidth=5, alpha=0.5)
 
 
+@pytest.mark.skipif('ligo.skymap' not in sys.modules,
+                    reason="requires ligo.skymap")
 def test_save(output_directory):
 
     file_name = Path(output_directory, "test_allskymap_plot.png")
@@ -45,7 +56,8 @@ def test_save(output_directory):
         pad_inches=0.5,
     )
 
-
+@pytest.mark.skipif('ligo.skymap' not in sys.modules,
+                    reason="requires ligo.skymap")
 def test_detector_plotting():
 
     detector = Detector(detector_properties)


### PR DESCRIPTION
Remove dependency from ligo.skymap from fancy.

We generate a try/except within allskymap.py and raise an import error if it is not installed. Further pytest will skip running this test if ligo.skymap is not installed.